### PR TITLE
v1.1.1: consistently use bucketRegion, not regionName

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You will need a s3 bucket and the corresponding credentials.
 let challenge = require('greenlock-challenge-s3').create({
     accessKeyId: accessKeyId                // Replace with your accessKeyId
     , secretAccessKey: secretAccessKey      // Replace with your secretAccessKey
-    , regionName: regionName                // Replace with your regionName
+    , bucketRegion: bucketRegion            // Replace with your bucketRegion
     , bucketName: bucketName                // Replace with your bucketName
     , directory: 'acme-challenge/'          // Recommended
     , debug: true                           // Debug
@@ -52,11 +52,11 @@ To run the tests yourself, create a `.env` file with the following
 // .env file
 AWS_ACCESS_KEY_ID=abc           // Replace with your accessKeyId
 AWS_SECRET_ACCESS_KEY=abc       // Replace with your secretAccessKey
-AWS_BUCKET_REGION=abc           // Replace with your regionName
+AWS_BUCKET_REGION=abc           // Replace with your bucketRegion
 AWS_BUCKET_NAME=abc             // Replace with your bucketName
 ```
 
-Run the following command: 
+Run the following command:
 ```console
 $ npm run clean && npm run test && npm run clean
 ```

--- a/clean.js
+++ b/clean.js
@@ -4,13 +4,13 @@ require("dotenv").config();
 
 let accessKeyId = process.env.AWS_ACCESS_KEY_ID
     , secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
-    , regionName = process.env.AWS_BUCKET_REGION
+    , bucketRegion = process.env.AWS_BUCKET_REGION
     , bucketName = process.env.AWS_BUCKET_NAME;
 
 var AWS = require("aws-sdk");
 AWS.config.setPromisesDependency(Promise);
 AWS.config.update({
-    region: regionName
+    region: bucketRegion
     , credentials: new AWS.Credentials({
         accessKeyId: accessKeyId
         , secretAccessKey: secretAccessKey

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenlock-challenge-s3",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "S3 backed challenge strategy for greenlock-express.js (and greenlock.js)",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ require("dotenv").config();
 
 let accessKeyId = process.env.AWS_ACCESS_KEY_ID
     , secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
-    , regionName = process.env.AWS_BUCKET_REGION
+    , bucketRegion = process.env.AWS_BUCKET_REGION
     , bucketName = process.env.AWS_BUCKET_NAME;
 
 let tester = require("greenlock-challenge-test");
@@ -12,7 +12,7 @@ let tester = require("greenlock-challenge-test");
 let challenger = require("./index").create({
     accessKeyId
     , secretAccessKey
-    , regionName
+    , bucketRegion
     , bucketName
     , directory: "acme-challenge/"
     , debug: true


### PR DESCRIPTION
Same as with greenlock-storage-s3